### PR TITLE
Add incident management docs

### DIFF
--- a/incident-management/README.md
+++ b/incident-management/README.md
@@ -1,0 +1,24 @@
+## Incident Management
+
+This folder contains information pertaining to how the Operate First team will respond to incidents/outages.
+
+As we have multiple services/applications deployed and monitored in the Operate First environment (ex. Jupyterhub, Argo, Superset, Observatorium, Project Thoth, AICoE CI pipelines etc), we need to implement an incident reporting setup for handling outages/incidents related to these services. Whether its a major bug, capacity issues, or an outage, our users expect an immediate response. Having an efficient incident management process is critical in ensuring that the incidents are always communicated to the users (via on-call notification systems) and handled by the team immediately. An on-call notification system is a system/software that provides an automated means of contacting users and communicating pertinent information during an incident. It also has additional on-call scheduling features that can be used to ensure that the right people on the team are available to address a problem during an incident.
+
+### GitHub Alertmanager Receiver
+
+We have chosen the [GitHub Alertmanager](https://github.com/m-lab/alertmanager-github-receiver) as our tool for reporting the outages/incidents to our users. The GitHub alertmanager is a Prometheus alertmanager webhook receiver that creates GitHub issues from alerts. It can easily be configured and operated to function with Prometheus alerts. All communication/updates/concerns related to the incident can be easily handled by adding comments in the issues created by the GitHub receiver, making the incident management process completely transparent to our users. We can also configure GitHub bots for different chatting platforms such as Slack, Google Chat to notify us of the issues immediately.
+
+To deploy and setup your own GitHub alertmanager receiver, follow the instructions [here](https://github.com/operate-first/SRE/blob/master/incident-management/github-receiver-setup.md).
+
+### Alerting with Prometheus
+
+All the services are being monitored by Prometheus. Prometheus scrapes and stores time series data identified by metric key/value pairs for each of the available services. We use these metrics to define the [SLI/SLOs](https://github.com/operate-first/SRE/tree/master/sli-slo) for each of our services and alert on any possible service degradation.
+
+Alerting with Prometheus is separated into two parts:
+
+1. [Alerting rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)  in Prometheus servers send alerts to an [Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/). Alerting rules allow you to define alert conditions based on Prometheus expression language expressions.
+2. The Alertmanager then manages those alerts, including silencing, inhibition, aggregation and sending out notifications via methods such as email, on-call notification systems, and chat platforms.
+
+We have added our GitHub alertmanager receiver as the default receiver for our Prometheus alertmanager to route the alerts. For any alert that is being fired, the GitHub receiver will automatically create an issue in this repository like so: https://github.com/operate-first/SRE/issues/34.
+
+You can refer to the documentation [here](https://github.com/operate-first/SRE/blob/master/incident-management/configure-prometheus-alerts.md) which describes how these alerting rules are setup for our Operate First monitoring stack.

--- a/incident-management/configure-prometheus-alerts.md
+++ b/incident-management/configure-prometheus-alerts.md
@@ -1,0 +1,62 @@
+# Configuring Prometheus Alerts
+
+Our Prometheus instance can be reached at:  http://prometheus-portal-opf-monitoring.apps.cnv.massopen.cloud/graph.
+Follow the instructions described below for configuring alerts to our Prometheus instance.
+
+## Adding Alerts
+
+If you wish to add new alerts for your team/applications to our Prometheus instance, you will need to:
+
+1. Define your Prometheus alerting rules in a `example-prometheus-rules.yaml` file in our [`operate-first/apps`](https://github.com/operate-first/apps/) repo:
+
+```yaml
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: odh-monitoring
+    role: alert-rules
+  name: example-prometheus-alerting-rules
+spec:
+  groups:
+    - name: Example Rules
+      rules:
+        - alert: ExampleAlert
+          expr: vector(1)
+          for: 2m
+          annotations:
+            summary: "This is an example alert"
+```
+Save this file under `odh/overlays/moc/monitoring/alerts/example-prometheus-rules.yaml`.
+
+3. Add your prometheus alerting rule file to `odh/overlays/moc/monitoring/alerts/kustomization.yaml` by running the following:
+
+````bash
+$ cd odh/overlays/moc/monitoring/alerts/
+$ kustomize edit add resource example-prometheus-rules.yaml
+````
+
+4. Once you have the alerting rules defined, you will need to add your preferred alert receiver to which the alerts will be routed. The receiver can be Slack, Email, PagerDuty etc. We currently route our alerts to the [GitHub receiver](https://github.com/m-lab/alertmanager-github-receiver) which automatically creates issues in this repo for any alerts being fired. If you would like to try out the GitHub receiver, we would recommend you to have your own deployment so that you can configure it to create issues in your preferred repo(s) and customize it according to your needs. The deployment instructions can be found [here](https://github.com/operate-first/SRE/blob/master/incident-management/github-receiver-setup.md).
+
+5. Once you have your alert receiver setup, you will need to add this receiver to our Prometheus alertmanager config [here](https://github.com/operate-first/apps/blob/master/odh/base/monitoring/alertmanager-config.yaml):
+
+```yaml
+alertmanager.yaml: |
+    routes:
+    - match_re:
+        # This matches all metrics having the `job` label beginning with the string `example`
+        job: ^(example).*$
+        receiver: your-receiver
+
+    receivers:
+    - name: 'your-receiver'
+      webhook_configs:
+        - url: 'your-receiver-address'
+```
+
+In order to differentiate and route the alerts to their respective receivers, you will need to provide a suitable regex expression matching your metrics so that the alerts for those metrics only get routed to your receiver. This is specified in the `match_re` field.
+
+Depending on your receiver type, you will add it under the `receivers` field with a suitable name. For more information on the various receivers supported by Prometheus and how they are defined, you can refer to the documentation [here](https://prometheus.io/docs/alerting/latest/configuration/#receiver).
+
+6. Submit a PR with all the above changes to our `operate-first/apps` repo. Once it is successfully merged, you should be able to confirm and view your alerting rules here: http://prometheus-portal-opf-monitoring.apps.cnv.massopen.cloud/alerts!

--- a/incident-management/github-receiver-setup.md
+++ b/incident-management/github-receiver-setup.md
@@ -1,0 +1,75 @@
+# GitHub Alertmanager Receiver
+
+The [GitHub alertmanager receiver](https://github.com/m-lab/alertmanager-github-receiver) is a Prometheus alertmanager webhook receiver that creates GitHub issues from alerts. An example issue would look like https://github.com/operate-first/SRE/issues/34. The GitHub receiver can easily be configured and operated to function with Prometheus alerts. The typical flow of alerting would look like:
+
+`Prometheus (generates rules) -> Prometheus alertmanager (routes alerts) -> GitHub receiver (receives alerts)`
+
+## Setup Instructions
+
+### Prerequisites
+
+* An OCP cluster
+* GitHub account
+
+### Create GitHub access token
+
+The github receiver uses user access tokens to create issues in an existing
+repository.
+
+Generate a new access token:
+
+* Log into GitHub and visit https://github.com/settings/tokens
+* Click the 'Generate new token' button
+* Select the 'repo' scope and all subscopes of 'repo'
+
+Because this access token has permission to create issues and operate on
+repositories the access token user can access, protect the access token as
+you would a password.
+
+### Deploy GitHub Receiver
+
+1. To deploy the GitHub receiver, you can use the deployment configuration defined [here](https://github.com/operate-first/apps/blob/master/odh/base/monitoring/github-receiver.yaml). It is important to note that we need to specify the GitHub auth token in the `spec.containers.env` field which has permissions to create issues in your target repo(s):
+
+```yaml
+spec:
+      containers:
+        - name: github-receiver
+          image: quay.io/operate-first/alertmanager-github-receiver:v0.10
+          env:
+            - name: GITHUB_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-secrets
+                  key: auth-token
+```
+
+You can configure various arguments in the `spec.containers.args` field as follows:
+
+```yaml
+args:
+            - --authtoken=$(GITHUB_AUTH_TOKEN)
+            - --org=operate-first
+            - --repo=SRE
+            - --label=in progress
+            - --enable-inmemory=false
+            - --enable-auto-close=true
+```
+
+* `--authtoken` - your GitHub auth token
+* `--org` - the organization or user name in GitHub
+* `--repo` - the GitHub repo name you wish to have the issues created in
+* `--label` - labels to add to issues at creation time
+* `--enable-inmemory` - performs all operations in memory, without using github API
+* `--enable-auto-close` - once an alert stops firing, automatically close open issues
+
+are some of the additional parameters you can apply to your GitHub receiver.
+
+2. Ensure to add your GitHub auth token as a secret to your project namespace with the same name/key value as specified in the `secretKeyRef` field.
+
+3. Include a service definition for the GitHub receiver as defined [here](https://github.com/operate-first/apps/blob/master/odh/base/monitoring/github-receiver-service.yaml). The service produces a name usable in-cluster like:
+
+`GITHUB_RECEIVER_URL=http://github-receiver-service.default.svc.cluster.local:9393/v1/receiver`
+
+This is the webhook URL that we will need to provide in our Prometheus Alertmanager config, so that the alerts can be routed to it.
+
+Once this is completed successfully, you should have your GitHub receiver running and ready to be configured to a Prometheus alertmanager!


### PR DESCRIPTION
Adding documentation related to incident management, specifically:

- How to setup the GitHub alertmanager recevier
- How to configure alerts with Prometheus

This addresses https://github.com/operate-first/apps/issues/108 and operate-first/support#949 