### PR TITLE
Update JH SLI dashboard

### DIFF
--- a/dashboards/jupyterhub-sli-slo.json
+++ b/dashboards/jupyterhub-sli-slo.json
@@ -15,10 +15,35 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 3,
-  "iteration": 1607985612414,
+  "id": 13,
+  "iteration": 1613488593726,
   "links": [],
   "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 40,
+      "options": {
+        "content": "# JupyterHub SLI Dashboard\n\nThis dashboard helps visualize the SLIs (Service Level Indicators) important for monitoring the JupyterHub service.\n\nThe main SLIs tracked are:\n* Availability \n* Latency\n* Saturation\n* Error",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.1.0",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "JupyterHub SLI Dashboard",
+      "type": "text"
+    },
     {
       "collapsed": false,
       "datasource": null,
@@ -26,12 +51,12 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 8
       },
       "id": 19,
       "panels": [],
       "repeat": null,
-      "title": "Overview",
+      "title": "SLI: Availability",
       "type": "row"
     },
     {
@@ -47,7 +72,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 1
+        "y": 9
       },
       "id": 7,
       "links": [],
@@ -62,266 +87,65 @@
       "type": "text"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 6,
-        "y": 1
-      },
-      "hiddenSeries": false,
-      "id": 3,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.1.1",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "count(count(container_cpu_usage_seconds_total{namespace=\"$namespace\",pod_name=~\".*jupyterhub-nb.*\"}) by(pod_name))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A",
-          "step": 10
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Pods Running",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": 0,
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "rgba(245, 54, 54, 0.9)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(50, 172, 45, 0.97)"
-      ],
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 12,
-        "y": 1
-      },
-      "id": 4,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "count(container_accelerator_duty_cycle{pod_name=~\".*jupyterhub-nb.*\"})",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "refId": "A",
-          "step": 60
-        }
-      ],
-      "thresholds": "",
-      "title": "GPU enabled Pods",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 9
-      },
-      "id": 20,
-      "panels": [],
-      "repeat": null,
-      "title": "SLI: Availability",
-      "type": "row"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": "Prometheus",
+      "datasource": "opendatahub",
       "fieldConfig": {
         "defaults": {
           "custom": {},
           "mappings": [
             {
+              "from": "",
               "id": 0,
-              "op": "=",
               "text": "Up",
+              "to": "",
               "type": 1,
               "value": "1"
             },
             {
+              "from": "",
               "id": 1,
-              "op": "=",
               "text": "Down",
+              "to": "",
               "type": 1,
               "value": "0"
             }
           ],
-          "nullValueMode": "connected",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(245, 54, 54, 0.9)",
+                "color": "green",
                 "value": null
               },
               {
-                "color": "rgba(237, 129, 40, 0.89)",
-                "value": 0.1
+                "color": "dark-red",
+                "value": 0
               },
               {
-                "color": "rgba(50, 172, 45, 0.97)",
-                "value": 0.9
+                "color": "green",
+                "value": 1
               }
             ]
-          },
-          "unit": "none"
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 0,
-        "y": 10
+        "h": 7,
+        "w": 4,
+        "x": 7,
+        "y": 9
       },
-      "id": 17,
-      "interval": null,
-      "links": [],
-      "maxDataPoints": 100,
+      "id": 25,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
-        "orientation": "horizontal",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "mean"
+            "lastNotNull"
           ],
-          "fields": "/^up{endpoint=\"8080-tcp\", instance=\"10.129.2.41:8080\", job=\"jupyterhub\", namespace=\"opf-jupyterhub\", pod=\"jupyterhub-5-vx6x4\", prometheus=\"opf-jupyterhub/prometheus\", prometheus_replica=\"prometheus-prometheus-0\", service=\"jupyterhub\"}$/",
+          "fields": "",
           "values": false
         },
         "textMode": "auto"
@@ -330,13 +154,12 @@
       "targets": [
         {
           "expr": "up{service=\"jupyterhub\"}",
-          "format": "time_series",
-          "instant": true,
           "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "",
-          "refId": "A",
-          "step": 60
+          "refId": "A"
+        },
+        {
+          "refId": "B"
         }
       ],
       "timeFrom": null,
@@ -345,56 +168,67 @@
       "type": "stat"
     },
     {
-      "content": "# JupyterHub Startup time\nIn v1.2.1 there is a new metric `hub_startup_duration_seconds`which measures time taken for the Hub to start. This might be useful in calculating avg. startup time and measuring availability.",
       "datasource": null,
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-orange",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 6,
-        "y": 10
+        "h": 7,
+        "w": 4,
+        "x": 12,
+        "y": 9
       },
-      "id": 5,
+      "id": 3,
       "links": [],
-      "mode": "markdown",
       "options": {
-        "content": "# JupyterHub Startup time\nIn v1.2.1 there is a new metric `hub_startup_duration_seconds`which measures time taken for the Hub to start. This might be useful in calculating avg. startup time and measuring availability.",
-        "mode": "markdown"
-      },
-      "pluginVersion": "7.1.0",
-      "title": "JupyterHub Startup Time",
-      "type": "text"
-    },
-    {
-      "content": "New metrics for tracking user activity in v1.2.1:\n\n`total_users` -  Total number of users\n\n`running_servers` -  The number of user servers currently running",
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
         },
-        "overrides": []
+        "textMode": "auto"
       },
-      "gridPos": {
-        "h": 8,
-        "w": 10,
-        "x": 14,
-        "y": 10
-      },
-      "id": 9,
-      "links": [],
-      "mode": "markdown",
-      "options": {
-        "content": "New metrics for tracking user activity in v1.2.1:\n\n`total_users` -  Total number of users\n\n`running_servers` -  The number of user servers currently running",
-        "mode": "markdown"
-      },
-      "pluginVersion": "7.1.0",
-      "title": "User Activity",
-      "type": "text"
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "jupyterhub_running_servers",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Running Servers",
+          "refId": "A",
+          "step": 10
+        },
+        {
+          "expr": "jupyterhub_total_users",
+          "interval": "",
+          "legendFormat": "Total Users",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "JupyterHub Users",
+      "type": "stat"
     },
     {
       "collapsed": false,
@@ -403,7 +237,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 17
       },
       "id": 21,
       "panels": [],
@@ -412,396 +246,172 @@
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "custom": {}
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
-        "h": 15,
-        "w": 6,
-        "x": 0,
-        "y": 19
+        "h": 3,
+        "w": 7,
+        "x": 1,
+        "y": 18
       },
-      "hiddenSeries": false,
-      "id": 8,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
+      "id": 35,
+      "options": {
+        "content": "The panel below displays the time taken for spawners to initialize and the histogram bucket distribution is visualized.",
+        "mode": "markdown"
       },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.1.1",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "server_spawn_duration_seconds_count{job=\"JupyterHub Metrics\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{status}}",
-          "refId": "A",
-          "step": 20
-        }
-      ],
-      "thresholds": [],
+      "pluginVersion": "7.1.0",
       "timeFrom": null,
-      "timeRegions": [],
       "timeShift": null,
-      "title": "Server Spawn Operations",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "title": "Init Server Spawn Duration",
+      "type": "text"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "custom": {}
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
-        "h": 15,
-        "w": 4,
-        "x": 6,
-        "y": 19
-      },
-      "hiddenSeries": false,
-      "id": 10,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.1.1",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "kube_pod_container_status_restarts_total{namespace=\"$namespace\", pod=~\"jupyterhub-nb.*\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{pod}}",
-          "refId": "A",
-          "step": 30
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Hub Pod Restart Count",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 15,
-        "w": 6,
-        "x": 10,
-        "y": 19
-      },
-      "hiddenSeries": false,
-      "id": 12,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.1.1",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "request_duration_seconds_count{job=\"JupyterHub Metrics\", code=\"$error_codes\", method=\"GET\"}",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "",
-          "refId": "A",
-          "step": 20
-        },
-        {
-          "expr": "",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Error Codes",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 15,
+        "h": 3,
         "w": 8,
-        "x": 16,
-        "y": 19
+        "x": 13,
+        "y": 18
       },
-      "hiddenSeries": false,
-      "id": 13,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
+      "id": 36,
+      "options": {
+        "content": "The panel below displays the time taken for Hub to start and the histogram bucket distribution is visualized.",
+        "mode": "markdown"
       },
-      "lines": true,
-      "linewidth": 1,
+      "pluginVersion": "7.1.0",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Hub Startup Duration",
+      "type": "text"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 10,
+        "x": 0,
+        "y": 21
+      },
+      "id": 8,
       "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
       "pluginVersion": "7.1.1",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
       "targets": [
         {
-          "expr": "increase(server_spawn_duration_seconds_count{status=\"failure\"}[5m])",
-          "format": "time_series",
+          "expr": "jupyterhub_init_spawners_duration_seconds_bucket",
+          "format": "heatmap",
+          "instant": false,
+          "interval": "",
           "intervalFactor": 2,
+          "legendFormat": "{{le}}",
           "refId": "A",
-          "step": 10
-        },
-        {
-          "expr": "",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "refId": "B"
+          "step": 20
         }
       ],
-      "thresholds": [],
       "timeFrom": null,
-      "timeRegions": [],
       "timeShift": null,
-      "title": "JupyterHub Notebook Servers Fail Rate",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+      "title": "Init Server Spawn Duration",
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 11,
+        "x": 12,
+        "y": 21
+      },
+      "id": 27,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "expr": "jupyterhub_hub_startup_duration_seconds_bucket",
+          "format": "heatmap",
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
         }
       ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Hub Startup Duration",
+      "type": "bargauge"
     },
     {
       "collapsed": false,
@@ -810,13 +420,63 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 35
       },
       "id": 22,
       "panels": [],
       "repeat": null,
-      "title": "SLI: Quality & Performance",
+      "title": "SLI: Saturation",
       "type": "row"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 7,
+        "x": 2,
+        "y": 36
+      },
+      "id": 38,
+      "options": {
+        "content": "The panel below displays the CPU usage (%) for JupyterHub users over time.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.1.0",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Pod CPU  Usage",
+      "type": "text"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 7,
+        "x": 14,
+        "y": 36
+      },
+      "id": 37,
+      "options": {
+        "content": "The panel below displays the memory usage (in `GiB`) for JupyterHub users over time.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.1.0",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Pod Memory Usage",
+      "type": "text"
     },
     {
       "aliasColors": {},
@@ -833,10 +493,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 10,
-        "w": 8,
+        "h": 14,
+        "w": 11,
         "x": 0,
-        "y": 35
+        "y": 39
       },
       "hiddenSeries": false,
       "id": 1,
@@ -864,11 +524,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\".*jupyter.*\"}[2m])) by (pod_name)",
+          "expr": "(sum(rate(container_cpu_usage_seconds_total{pod=~\"jupyterhub-nb.*\"}[5m])) by (pod))*100",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "{{pod}}",
           "refId": "A",
           "step": 10
         }
@@ -877,7 +537,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "JupyterHub CPU Usage",
+      "title": "Pod CPU Usage",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -893,7 +553,8 @@
       },
       "yaxes": [
         {
-          "format": "percentunit",
+          "$$hashKey": "object:1162",
+          "format": "none",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -901,6 +562,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1163",
           "format": "percentunit",
           "label": null,
           "logBase": 1,
@@ -929,10 +591,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 10,
-        "w": 8,
-        "x": 8,
-        "y": 35
+        "h": 14,
+        "w": 11,
+        "x": 12,
+        "y": 39
       },
       "hiddenSeries": false,
       "id": 2,
@@ -960,11 +622,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_rss{pod_name=~\".*jupyter.*\"}) by (pod_name)",
+          "expr": "sum(container_memory_rss{pod=~\"jupyterhub-nb.*\"}) by (pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "{{pod}}",
           "refId": "A",
           "step": 10
         }
@@ -973,7 +635,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Jupyterhub Memory usage",
+      "title": "Pod Memory usage",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -989,6 +651,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1262",
           "format": "bytes",
           "label": null,
           "logBase": 1,
@@ -997,6 +660,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1263",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1011,11 +675,36 @@
       }
     },
     {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 9,
+        "x": 7,
+        "y": 53
+      },
+      "id": 31,
+      "options": {
+        "content": "The panel below displays the PVC storage usage (%) for a specific JupyterHub user. To view the JupyterHub PVC storage for a user in the panel below, select the user id from `User ID` drop-down filter available on the top of this dashboard page.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.1.0",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "PVC Storage Usage",
+      "type": "text"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -1025,10 +714,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 10,
-        "w": 8,
-        "x": 16,
-        "y": 35
+        "h": 16,
+        "w": 11,
+        "x": 6,
+        "y": 56
       },
       "hiddenSeries": false,
       "id": 14,
@@ -1058,9 +747,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kubelet_volume_stats_used_bytes{namespace='$namespace',persistentvolumeclaim=~\".*$kerberos_id.*\"}/kubelet_volume_stats_capacity_bytes{namespace='$namespace',persistentvolumeclaim=~\".*$kerberos_id.*\"}",
+          "expr": "(kubelet_volume_stats_used_bytes{namespace=\"opf-jupyterhub\",persistentvolumeclaim=~\"jupyterhub-nb-$user_id-pvc\", pod=\"prometheus-k8s-0\"})/(kubelet_volume_stats_capacity_bytes{namespace=\"opf-jupyterhub\",persistentvolumeclaim=~\"jupyterhub-nb-$user_id-pvc\",pod=\"prometheus-k8s-0\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
+          "legendFormat": "{{persistentvolumeclaim}}",
           "refId": "A",
           "step": 10
         }
@@ -1069,7 +760,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "JupyterHub Storage Capacity for  $kerberos_id",
+      "title": "PVC Storage Usage (%) for  $user_id",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1085,6 +776,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1370",
           "format": "percentunit",
           "label": null,
           "logBase": 1,
@@ -1093,6 +785,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1371",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1113,13 +806,63 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 72
       },
       "id": 23,
       "panels": [],
       "repeat": null,
-      "title": "Kube Pod Metrics",
+      "title": "SLI: Error",
       "type": "row"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 1,
+        "y": 73
+      },
+      "id": 30,
+      "options": {
+        "content": "The panel below displays the server spawn fail rate for JupyterHub servers running. The fail rate is calculated over a duration of `5m`.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.1.0",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "JupyterHub Server Spawn Fail Rate",
+      "type": "text"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 7,
+        "x": 14,
+        "y": 73
+      },
+      "id": 29,
+      "options": {
+        "content": "The panel below displays the Hub pod restart count.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.1.0",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Hub Pod Restart Count",
+      "type": "text"
     },
     {
       "aliasColors": {},
@@ -1136,10 +879,278 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 14,
-        "w": 12,
+        "h": 16,
+        "w": 10,
         "x": 0,
-        "y": 46
+        "y": 76
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "increase(jupyterhub_server_spawn_duration_seconds_count{status=\"failure\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A",
+          "step": 10
+        },
+        {
+          "expr": "",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "JupyterHub Server Spawn Fail Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1083",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1084",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 16,
+        "w": 11,
+        "x": 12,
+        "y": 76
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "kube_pod_container_status_restarts_total{pod=~\"jupyterhub-[0-9].*\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Hub Pod Restart Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:771",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:772",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 7,
+        "x": 1,
+        "y": 92
+      },
+      "id": 32,
+      "options": {
+        "content": "The panel below displays the pods for JupyterHub which where `OOMKilled`",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.1.0",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "OOMKilled Pods",
+      "type": "text"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 9,
+        "x": 13,
+        "y": 92
+      },
+      "id": 33,
+      "options": {
+        "content": "The panel below displays the count of HTTP requests for various JupyterHub operations based on the HTTP status code. Select the HTTP status code from the `status_codes` drop-down filter available on top of this dashboard page to view the results.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.1.0",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "HTTP Requests Error Codes",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 18,
+        "w": 10,
+        "x": 0,
+        "y": 95
       },
       "hiddenSeries": false,
       "id": 15,
@@ -1167,29 +1178,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum_over_time(kube_pod_container_status_terminated_reason{namespace=\"$namespace\", pod=~\"jupyterhub-nb-.*\", reason=\"OOMKilled\"}[1h])",
+          "expr": "sum_over_time(kube_pod_container_status_terminated_reason{namespace=\"opf-jupyterhub\", pod=~\"jupyterhub-nb-.*\", reason=\"OOMKilled\"}[1h])",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{pod}}",
           "refId": "A",
           "step": 10
-        },
-        {
-          "expr": "kube_pod_container_status_restarts_total{namespace=\"$namespace\", pod=~\"jupyterhub-nb-.*\"}",
-          "format": "time_series",
-          "hide": true,
-          "intervalFactor": 2,
-          "legendFormat": "{{pod}}",
-          "refId": "B",
-          "step": 20
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "OOMKilled Pods (needs to be modified)",
+      "title": "OOMKilled Pods",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1205,6 +1208,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1692",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1213,6 +1217,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1693",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -1227,7 +1232,10 @@
       }
     },
     {
-      "columns": [],
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
@@ -1235,60 +1243,189 @@
         },
         "overrides": []
       },
-      "fontSize": "100%",
+      "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
-        "h": 14,
-        "w": 12,
+        "h": 18,
+        "w": 11,
         "x": 12,
-        "y": 46
+        "y": 95
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "jupyterhub_request_duration_seconds_count{code=~\"$status_codes\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{code}},{{handler}}",
+          "refId": "A",
+          "step": 20
+        },
+        {
+          "expr": "",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "HTTP Request Error Codes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2435",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2436",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 1,
+        "y": 113
+      },
+      "id": 34,
+      "options": {
+        "content": "The panel below displays the pods/containers which encountered an error during container creation. The possible errors can be:\n* `ErrImagePull`\n* `ImagePullBackOff`\n* `CrashLoopBackoff`\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.1.0",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Container Creation Errors",
+      "type": "text"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 20,
+        "w": 9,
+        "x": 0,
+        "y": 120
       },
       "id": 18,
       "links": [],
-      "pageSize": null,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": true
+      "options": {
+        "showHeader": true
       },
-      "styles": [
-        {
-          "alias": "Time",
-          "align": "auto",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "date"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "decimals": 2,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
-          "unit": "short"
-        }
-      ],
+      "pluginVersion": "7.1.1",
       "targets": [
         {
-          "expr": "count(kube_pod_container_status_waiting_reason{namespace=\"$namespace\",pod=~\"jupyterhub-nb-.*\", reason=~\"CrashLoopBackOff|ErrImagePull|ImagePullBackOff\"} == 1) by(reason,pod)",
+          "expr": "kube_pod_container_status_waiting_reason{namespace=\"opf-jupyterhub\", reason=~\"CrashLoopBackOff|ErrImagePull|ImagePullBackOff\", pod=~\"jupyterhub-nb.*\", prometheus_replica=\"prometheus-k8s-0\"}",
           "format": "table",
+          "instant": false,
           "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "",
-          "refId": "A",
-          "step": 10
+          "refId": "A"
         }
       ],
+      "timeFrom": null,
+      "timeShift": null,
       "title": "Container Creation Errors",
-      "transform": "table",
-      "type": "table-old"
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "pod",
+                "container",
+                "reason",
+                "Value"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "refresh": false,
@@ -1301,9 +1438,9 @@
     "list": [
       {
         "current": {
-          "selected": true,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "selected": false,
+          "text": "opendatahub",
+          "value": "opendatahub"
         },
         "hide": 0,
         "includeAll": false,
@@ -1322,71 +1459,18 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": "$datasource",
-        "definition": "",
-        "hide": 0,
-        "includeAll": true,
-        "label": null,
-        "multi": false,
-        "name": "error_codes",
-        "options": [],
-        "query": "label_values(request_duration_seconds_count{job=\"JupyterHub Metrics\"},code)",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {
-          "selected": false,
-          "text": "jupyterhub.apihandlers.auth.OAuthHandler",
-          "value": "jupyterhub.apihandlers.auth.OAuthHandler"
-        },
-        "datasource": "$datasource",
-        "definition": "",
-        "hide": 0,
-        "includeAll": false,
-        "label": null,
-        "multi": false,
-        "name": "handler",
-        "options": [],
-        "query": "label_values(request_duration_seconds_count,handler)",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {
-          "isNone": true,
-          "selected": true,
-          "text": "None",
+          "text": "",
           "value": ""
         },
-        "datasource": "Prometheus",
-        "definition": "",
+        "datasource": "opendatahub",
+        "definition": "kubelet_volume_stats_capacity_bytes",
         "hide": 0,
         "includeAll": false,
-        "label": "Kerberos ID",
+        "label": "User ID",
         "multi": false,
-        "name": "kerberos_id",
+        "name": "user_id",
         "options": [],
-        "query": "kubelet_volume_stats_used_bytes{namespace='dh-prod-jupyterhub'}",
+        "query": "kubelet_volume_stats_capacity_bytes",
         "refresh": 1,
         "regex": "/.*persistentvolumeclaim=\\\"jupyterhub-nb-(.*)-pvc\\\".*/",
         "skipUrlSync": false,
@@ -1400,20 +1484,19 @@
       {
         "allValue": null,
         "current": {
-          "isNone": true,
           "selected": false,
-          "text": "None",
-          "value": ""
+          "text": "503",
+          "value": "503"
         },
         "datasource": "$datasource",
-        "definition": "",
+        "definition": "label_values(jupyterhub_request_duration_seconds_count{job=\"jupyterhub\"},code)",
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
-        "name": "namespace",
+        "name": "status_codes",
         "options": [],
-        "query": "label_values(container_cpu_usage_seconds_total,namespace)",
+        "query": "label_values(jupyterhub_request_duration_seconds_count{job=\"jupyterhub\"},code)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
Updating the JH SLI dashboard: https://grafana-route-opf-monitoring.apps.cnv.massopen.cloud/d/BfSK2f1Mz/jupyterhub-sli-slo
based on refinement work done in collaboration with the Internal Data Hub team :tada: 