### PR TITLE
chore: Remove martin from reviewers so he's not flooded by notifications

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -13,6 +13,5 @@ reviewers:
   - hemajv
   - HumairAK
   - tumido
-  - martinpovolny
   - larsks
   - ipolonsk


### PR DESCRIPTION
Let's relieve this poor man's inbox pressure! This change makes sesheta stop assigning @martinpovolny to reviews and PRs (yes, I had to tag him here for the last time :smirk: :grin: ). 