### PR TITLE
Update all remaining SRE docs with mentions of the zero cluster

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -10,7 +10,7 @@ Dashboards can be represented by the `GrafanaDashboard` custom resource or by th
 
 ## Adding the Dashboards
 
-The Operate First Grafana instance can be accessed at: https://grafana-route-opf-monitoring.apps.zero.massopen.cloud/.
+The Operate First Grafana instance can be accessed [here]( https://grafana.operate-first.cloud/)
 
 To include additional Operate First monitoring dashboards to Grafana, you will need to:
 

--- a/incident-management/configure-prometheus-alerts.md
+++ b/incident-management/configure-prometheus-alerts.md
@@ -1,6 +1,5 @@
 # Configuring Prometheus Alerts
 
-Our Prometheus instance can be reached at:  http://prometheus-portal-opf-monitoring.apps.zero.massopen.cloud/graph.
 Follow the instructions described below for configuring alerts to our Prometheus instance.
 
 ## Adding Alerts
@@ -59,4 +58,4 @@ In order to differentiate and route the alerts to their respective receivers, yo
 
 Depending on your receiver type, you will add it under the `receivers` field with a suitable name. For more information on the various receivers supported by Prometheus and how they are defined, you can refer to the documentation [here](https://prometheus.io/docs/alerting/latest/configuration/#receiver).
 
-6. Submit a PR with all the above changes to our `operate-first/apps` repo. Once it is successfully merged, you should be able to confirm and view your alerting rules here: http://prometheus-portal-opf-monitoring.apps.zero.massopen.cloud/alerts!
+6. Submit a PR with all the above changes to our `operate-first/apps` repo.


### PR DESCRIPTION
These changes have been made to 2 documents (motivated by the issue operate-first/support#719 ) in which the links that reference to the zero cluster have either been replaced by the more updated links or removed.